### PR TITLE
fix: 対称オイラー角(XZX/ZXZ)の逆変換式の誤りを修正

### DIFF
--- a/Assets/MatrixHelper/Runtime/MatrixUtils.cs
+++ b/Assets/MatrixHelper/Runtime/MatrixUtils.cs
@@ -197,32 +197,52 @@ namespace nitou {
 
         // -----
 
+        /// <summary>
+        /// 回転行列からXZX-オイラー角を取得する．
+        /// </summary>
+        /// <remarks>R = Rx(s1)・Rz(p)・Rx(s2)</remarks>
+        /// <param name="mat">XZXオイラー角の回転行列</param>
         public static EulerAngles2 GetEulerAnglesXZX(Matrix4x4 mat) {
-            float s1 = Mathf.Atan2(mat.m10, mat.m20);
+            // p は inner 軸(Z)回りの回転角．m00 = cos(p)
             float p = Mathf.Acos(Mathf.Clamp(mat.m00, -1.0f, 1.0f));
-            float s2 = Mathf.Atan2(mat.m01, -mat.m02);
+
+            float s1, s2;
+            // sin(p) ≈ 0 のとき s1 と s2 が縮退するため、s2 = 0 として s1 を求める
+            if (Mathf.Approximately(p, 0)) {
+                s2 = 0;
+                s1 = Mathf.Atan2(mat.m21, mat.m11);
+            } else if (Mathf.Approximately(p, Mathf.PI)) {
+                s2 = 0;
+                s1 = Mathf.Atan2(-mat.m21, -mat.m11);
+            } else {
+                s1 = Mathf.Atan2(mat.m20, mat.m10);
+                s2 = Mathf.Atan2(mat.m02, -mat.m01);
+            }
 
             return new EulerAngles2(EulerAngles2.Type.XZX, s1, p, s2);
         }
 
 
+        /// <summary>
+        /// 回転行列からZXZ-オイラー角を取得する．
+        /// </summary>
+        /// <remarks>R = Rz(s1)・Rx(p)・Rz(s2)</remarks>
+        /// <param name="mat">ZXZオイラー角の回転行列</param>
         public static EulerAngles2 GetEulerAnglesZXZ(Matrix4x4 mat) {
-            // ZXZオイラー角の計算
-            float s1 = Mathf.Atan2(mat.m10, mat.m20);   // 最初のZ軸回転
-            float p = Mathf.Acos(Mathf.Clamp(mat.m00, -1.0f, 1.0f)); // X軸回転
-            float s2 = Mathf.Atan2(mat.m01, -mat.m02);  // 2回目のZ軸回転
+            // p は inner 軸(X)回りの回転角．m22 = cos(p)
+            float p = Mathf.Acos(Mathf.Clamp(mat.m22, -1.0f, 1.0f));
+
+            float s1, s2;
+            // sin(p) ≈ 0 のとき s1 と s2 が縮退するため、s2 = 0 として s1 を求める
+            if (Mathf.Approximately(p, 0) || Mathf.Approximately(p, Mathf.PI)) {
+                s2 = 0;
+                s1 = Mathf.Atan2(mat.m10, mat.m00);
+            } else {
+                s1 = Mathf.Atan2(mat.m02, -mat.m12);
+                s2 = Mathf.Atan2(mat.m20, mat.m21);
+            }
 
             return new EulerAngles2(EulerAngles2.Type.ZXZ, s1, p, s2);
-        }
-
-        public static EulerAngles2 GetEulerAnglesZYZ(Matrix4x4 mat) {
-
-            // ZYZオイラー角の計算
-            float s1 = Mathf.Atan2(mat.m10, mat.m00);   // 最初のZ軸回転
-            float p = Mathf.Acos(Mathf.Clamp(mat.m11, -1.0f, 1.0f)); // Y軸回転
-            float s2 = Mathf.Atan2(mat.m21, -mat.m22);  // 2回目のZ軸回転
-
-            return new EulerAngles2(EulerAngles2.Type.ZYZ, s1, p, s2);
         }
 
         /// <summary>

--- a/Assets/MatrixHelper/Tests/MatrixUtilsTest.cs
+++ b/Assets/MatrixHelper/Tests/MatrixUtilsTest.cs
@@ -86,6 +86,53 @@ namespace nitou.Tests {
             Assert.That(outputEuler, Is.EqualTo(inputEuler));
         }
 
+        // [NOTE] 対称オイラー角(i-j-i)では中間角 p が Acos により [0,180] に制限されるため、
+        //  往復が一意に決まる範囲（p∈[0,180]、特異点 p∈{0,180} では s2=0）でケースを選定している．
+
+        [TestCase(0, 0, 0)]     // 特異点 (p=0)
+        [TestCase(90, 0, 0)]    // 特異点 (p=0)
+        [TestCase(50, 180, 0)]  // 特異点 (p=180)
+        [TestCase(30, 45, 80)]
+        [TestCase(0, 90, 0)]
+        [TestCase(-30, 60, 80)]
+        [TestCase(45, 135, -60)]
+        public void XZXオイラー角が回転行列を介して正しく復元されること(float s1, float p, float s2) {
+            // Arrange
+            var angles = new Vector3(s1, p, s2) * Mathf.Deg2Rad;
+            var inputEuler = new EulerAngles2(EulerAngles2.Type.XZX, angles.x, angles.y, angles.z);
+
+            // Act
+            var mat = inputEuler.ToMatrix();
+            var outputEuler = MatrixUtils.GetEulerAnglesXZX(mat);
+
+            // Assert
+            Debug.Log(inputEuler.ToStringDeg());
+            Debug.Log(outputEuler.ToStringDeg());
+            Assert.That(outputEuler, Is.EqualTo(inputEuler));
+        }
+
+        [TestCase(0, 0, 0)]     // 特異点 (p=0)
+        [TestCase(90, 0, 0)]    // 特異点 (p=0)
+        [TestCase(50, 180, 0)]  // 特異点 (p=180)
+        [TestCase(30, 45, 80)]
+        [TestCase(0, 90, 0)]
+        [TestCase(-30, 60, 80)]
+        [TestCase(45, 135, -60)]
+        public void ZXZオイラー角が回転行列を介して正しく復元されること(float s1, float p, float s2) {
+            // Arrange
+            var angles = new Vector3(s1, p, s2) * Mathf.Deg2Rad;
+            var inputEuler = new EulerAngles2(EulerAngles2.Type.ZXZ, angles.x, angles.y, angles.z);
+
+            // Act
+            var mat = inputEuler.ToMatrix();
+            var outputEuler = MatrixUtils.GetEulerAnglesZXZ(mat);
+
+            // Assert
+            Debug.Log(inputEuler.ToStringDeg());
+            Debug.Log(outputEuler.ToStringDeg());
+            Assert.That(outputEuler, Is.EqualTo(inputEuler));
+        }
+
 
 
 


### PR DESCRIPTION
## 概要
`MatrixUtils.GetEulerAnglesXZX` と `GetEulerAnglesZXZ` の抽出式の誤りを修正します。

> ⚠️ このPRは #3 の上に積んでいます（base = `claude/fix-encoding`）。先に #3 をマージしてください。

## 問題
2つのメソッドが**完全に同一の式**になっていました。

```csharp
// XZX も ZXZ も同じ（誤り）
s1 = Atan2(m10, m20);
p  = Acos(m00);
s2 = Atan2(m01, -m02);
```

XZX (`Rx(s1)·Rz(p)·Rx(s2)`) と ZXZ (`Rz(s1)·Rx(p)·Rz(s2)`) は別の回転列なので、同じ抽出式にはなりません。両方とも誤った行列要素を参照しており、テストも無かったため検出されていませんでした。

加えて、ZYZ の抽出メソッドが2つ存在し、`GetEulerAnglesZYZ` は中間角に `Acos(m11)`（本来は `m22`）を使う**誤実装**かつ未使用でした。

## 変更内容
- `GetEulerAnglesXZX` / `GetEulerAnglesZXZ` を各回転列から導出した正しい式へ修正
  - XZX: `p=Acos(m00)`, `s1=Atan2(m20,m10)`, `s2=Atan2(m02,-m01)`
  - ZXZ: `p=Acos(m22)`, `s1=Atan2(m02,-m12)`, `s2=Atan2(m20,m21)`
  - `sin(p)≈0`（p=0, p=180）の特異点における縮退処理を追加
- 誤実装の重複メソッド `GetEulerAnglesZYZ` を削除（正しい `FromRotationMatrixZYZ` に集約）
- XZX/ZXZ の「オイラー角→回転行列→オイラー角」往復テストを追加

## 検証についての注意
当環境ではUnityのテスト実行ができないため、抽出式は各回転列の行列を手計算で導出して確認しています。マージ前にUnity Test Runnerでの実行をお願いします（追加テストが検証用に入っています）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dr6RhEUTL5GNFYk3aPywr3)_