### PR TITLE
feat: クォータニオン/軸‐角度（AxisAngle）との相互変換を追加（右手系）

### DIFF
--- a/Assets/MatrixHelper/Runtime/Euler/EulerAngles.Rotation.cs
+++ b/Assets/MatrixHelper/Runtime/Euler/EulerAngles.Rotation.cs
@@ -1,0 +1,57 @@
+using UnityEngine;
+
+namespace nitou {
+
+    // クォータニオン・軸‐角度との相互変換（右手系．QuaternionUtils と整合）
+    public partial struct EulerAngles {
+
+        /// <summary>
+        /// クォータニオン (x,y,z,w) に変換する．
+        /// </summary>
+        public Quaternion ToQuaternion() => QuaternionUtils.ToQuaternion(ToMatrix());
+
+        /// <summary>
+        /// 軸‐角度に変換する．
+        /// </summary>
+        public AxisAngle ToAxisAngle() => AxisAngle.FromMatrix(ToMatrix());
+
+        /// <summary>
+        /// クォータニオン (x,y,z,w) から指定順序のオイラー角を取得する．
+        /// </summary>
+        public static EulerAngles FromQuaternion(Type order, Quaternion q)
+            => MatrixUtils.ToEulerAngles(QuaternionUtils.FromQuaternion(q), order);
+
+        /// <summary>
+        /// 軸‐角度から指定順序のオイラー角を取得する．
+        /// </summary>
+        public static EulerAngles FromAxisAngle(Type order, AxisAngle axisAngle)
+            => MatrixUtils.ToEulerAngles(axisAngle.ToMatrix(), order);
+    }
+
+
+    // クォータニオン・軸‐角度との相互変換（対称オイラー角）
+    public partial struct EulerAngles2 {
+
+        /// <summary>
+        /// クォータニオン (x,y,z,w) に変換する．
+        /// </summary>
+        public Quaternion ToQuaternion() => QuaternionUtils.ToQuaternion(ToMatrix());
+
+        /// <summary>
+        /// 軸‐角度に変換する．
+        /// </summary>
+        public AxisAngle ToAxisAngle() => AxisAngle.FromMatrix(ToMatrix());
+
+        /// <summary>
+        /// クォータニオン (x,y,z,w) から指定順序の対称オイラー角を取得する．
+        /// </summary>
+        public static EulerAngles2 FromQuaternion(Type order, Quaternion q)
+            => MatrixUtils.ToEulerAngles(QuaternionUtils.FromQuaternion(q), order);
+
+        /// <summary>
+        /// 軸‐角度から指定順序の対称オイラー角を取得する．
+        /// </summary>
+        public static EulerAngles2 FromAxisAngle(Type order, AxisAngle axisAngle)
+            => MatrixUtils.ToEulerAngles(axisAngle.ToMatrix(), order);
+    }
+}

--- a/Assets/MatrixHelper/Runtime/Euler/EulerAngles.Rotation.cs.meta
+++ b/Assets/MatrixHelper/Runtime/Euler/EulerAngles.Rotation.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9082dcb8735e4de1b34b914df824490d

--- a/Assets/MatrixHelper/Runtime/Quartenion/AxisAngle.cs
+++ b/Assets/MatrixHelper/Runtime/Quartenion/AxisAngle.cs
@@ -1,0 +1,115 @@
+using System;
+using UnityEngine;
+
+namespace nitou {
+
+    /// <summary>
+    /// 軸‐角度（オイラーの回転定理）表現の回転を表す構造体．
+    /// </summary>
+    /// <remarks>
+    /// 右手系（<see cref="MatrixUtils"/> の Rx/Ry/Rz と整合）．
+    /// <see cref="Axis"/> は単位ベクトル，<see cref="Angle"/> は [rad]．
+    /// </remarks>
+    public readonly struct AxisAngle : IEquatable<AxisAngle> {
+
+        /// <summary>回転軸（単位ベクトル）．</summary>
+        public Vector3 Axis { get; }
+
+        /// <summary>回転角 [rad]．</summary>
+        public float Angle { get; }
+
+        // 定数
+        public static readonly float Tolerance = 1e-5f;
+
+        /// <summary>
+        /// コンストラクタ．軸は自動で正規化する．
+        /// </summary>
+        public AxisAngle(Vector3 axis, float angle) {
+            float m = axis.magnitude;
+            Axis = m > 1e-9f ? axis / m : Vector3.forward;
+            Angle = angle;
+        }
+
+        /// <summary>回転なし（恒等回転）．</summary>
+        public static AxisAngle Identity => new AxisAngle(Vector3.forward, 0f);
+
+        /// <summary>
+        /// 回転行列に変換する（ロドリゲスの公式）．
+        /// </summary>
+        public Matrix4x4 ToMatrix() {
+            float c = Mathf.Cos(Angle);
+            float s = Mathf.Sin(Angle);
+            float t = 1f - c;
+            float ax = Axis.x, ay = Axis.y, az = Axis.z;
+
+            var mat = Matrix4x4.identity;
+            mat.m00 = c + ax * ax * t;
+            mat.m01 = ax * ay * t - az * s;
+            mat.m02 = ax * az * t + ay * s;
+
+            mat.m10 = ay * ax * t + az * s;
+            mat.m11 = c + ay * ay * t;
+            mat.m12 = ay * az * t - ax * s;
+
+            mat.m20 = az * ax * t - ay * s;
+            mat.m21 = az * ay * t + ax * s;
+            mat.m22 = c + az * az * t;
+            return mat;
+        }
+
+        /// <summary>
+        /// クォータニオン (x,y,z,w) に変換する．
+        /// </summary>
+        public Quaternion ToQuaternion() {
+            float h = Angle * 0.5f;
+            float s = Mathf.Sin(h);
+            return new Quaternion(Axis.x * s, Axis.y * s, Axis.z * s, Mathf.Cos(h));
+        }
+
+        /// <summary>
+        /// クォータニオン (x,y,z,w) から軸‐角度を取得する．
+        /// </summary>
+        public static AxisAngle FromQuaternion(Quaternion q) {
+            float n = Mathf.Sqrt(q.x * q.x + q.y * q.y + q.z * q.z + q.w * q.w);
+            if (n < 1e-9f) return Identity;
+
+            float x = q.x / n, y = q.y / n, z = q.z / n, w = q.w / n;
+            float v = Mathf.Sqrt(x * x + y * y + z * z);   // = |sin(θ/2)|
+            if (v < 1e-9f) return new AxisAngle(Vector3.forward, 0f);
+
+            float angle = 2f * Mathf.Atan2(v, w);
+            return new AxisAngle(new Vector3(x, y, z) / v, angle);
+        }
+
+        /// <summary>
+        /// 回転行列から軸‐角度を取得する．
+        /// </summary>
+        public static AxisAngle FromMatrix(Matrix4x4 mat) => FromQuaternion(QuaternionUtils.ToQuaternion(mat));
+
+        /// <summary>
+        /// 同値判定．同じ回転を表す (axis,θ) と (-axis,-θ) は等価とみなす．
+        /// </summary>
+        public bool Equals(AxisAngle other) {
+            Quaternion a = ToQuaternion();
+            Quaternion b = other.ToQuaternion();
+            float dot = a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w;
+            return Mathf.Abs(dot) > 1f - Tolerance;   // 符号反転（二重被覆）も許容
+        }
+
+        public override bool Equals(object obj) => obj is AxisAngle other && Equals(other);
+
+        public override int GetHashCode() {
+            // Equals と整合させるため w >= 0 へ正規化した量子化値で算出
+            Quaternion q = ToQuaternion();
+            if (q.w < 0f) { q.x = -q.x; q.y = -q.y; q.z = -q.z; q.w = -q.w; }
+            const float scale = 1000f;
+            int hx = Mathf.RoundToInt(q.x * scale);
+            int hy = Mathf.RoundToInt(q.y * scale);
+            int hz = Mathf.RoundToInt(q.z * scale);
+            int hw = Mathf.RoundToInt(q.w * scale);
+            return HashCode.Combine(hx, hy, hz, hw);
+        }
+
+        public override string ToString() => $"AxisAngle(axis: {Axis}, angle: {Angle * Mathf.Rad2Deg}deg)";
+    }
+}

--- a/Assets/MatrixHelper/Runtime/Quartenion/AxisAngle.cs.meta
+++ b/Assets/MatrixHelper/Runtime/Quartenion/AxisAngle.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: aa6909bb43b04456926edb2684e4566a

--- a/Assets/MatrixHelper/Runtime/Quartenion/QuaternionUtils.cs
+++ b/Assets/MatrixHelper/Runtime/Quartenion/QuaternionUtils.cs
@@ -1,0 +1,74 @@
+using UnityEngine;
+
+namespace nitou {
+
+    /// <summary>
+    /// 回転行列とクォータニオンの相互変換を提供する静的クラス．
+    /// </summary>
+    /// <remarks>
+    /// [NOTE] 本ライブラリの回転は右手系（<see cref="MatrixUtils.Rx"/> /
+    /// <see cref="MatrixUtils.Ry"/> / <see cref="MatrixUtils.Rz"/> と整合）で定義する．
+    /// 返す <see cref="Quaternion"/> は (x,y,z,w) のデータ容器として扱い，右手系の
+    /// 標準式で構成する．Unity の <c>Transform.rotation</c>（左手系）とは規約が異なる
+    /// ため，得られたクォータニオンをそのまま transform に代入しないこと．
+    /// </remarks>
+    public static class QuaternionUtils {
+
+        /// <summary>
+        /// クォータニオン (x,y,z,w) から回転行列を生成する．
+        /// </summary>
+        public static Matrix4x4 FromQuaternion(Quaternion q) {
+            float x = q.x, y = q.y, z = q.z, w = q.w;
+
+            var mat = Matrix4x4.identity;
+            mat.m00 = 1f - 2f * (y * y + z * z);
+            mat.m01 = 2f * (x * y - z * w);
+            mat.m02 = 2f * (x * z + y * w);
+
+            mat.m10 = 2f * (x * y + z * w);
+            mat.m11 = 1f - 2f * (x * x + z * z);
+            mat.m12 = 2f * (y * z - x * w);
+
+            mat.m20 = 2f * (x * z - y * w);
+            mat.m21 = 2f * (y * z + x * w);
+            mat.m22 = 1f - 2f * (x * x + y * y);
+            return mat;
+        }
+
+        /// <summary>
+        /// 回転行列からクォータニオン (x,y,z,w) を取得する．
+        /// </summary>
+        /// <remarks>数値的に安定な Shepperd 法（最大成分で分岐）を用いる．</remarks>
+        public static Quaternion ToQuaternion(Matrix4x4 mat) {
+            float trace = mat.m00 + mat.m11 + mat.m22;
+            float x, y, z, w;
+
+            if (trace > 0f) {
+                float s = Mathf.Sqrt(trace + 1f) * 2f;          // s = 4w
+                w = 0.25f * s;
+                x = (mat.m21 - mat.m12) / s;
+                y = (mat.m02 - mat.m20) / s;
+                z = (mat.m10 - mat.m01) / s;
+            } else if (mat.m00 > mat.m11 && mat.m00 > mat.m22) {
+                float s = Mathf.Sqrt(1f + mat.m00 - mat.m11 - mat.m22) * 2f; // s = 4x
+                w = (mat.m21 - mat.m12) / s;
+                x = 0.25f * s;
+                y = (mat.m01 + mat.m10) / s;
+                z = (mat.m02 + mat.m20) / s;
+            } else if (mat.m11 > mat.m22) {
+                float s = Mathf.Sqrt(1f + mat.m11 - mat.m00 - mat.m22) * 2f; // s = 4y
+                w = (mat.m02 - mat.m20) / s;
+                x = (mat.m01 + mat.m10) / s;
+                y = 0.25f * s;
+                z = (mat.m12 + mat.m21) / s;
+            } else {
+                float s = Mathf.Sqrt(1f + mat.m22 - mat.m00 - mat.m11) * 2f; // s = 4z
+                w = (mat.m10 - mat.m01) / s;
+                x = (mat.m02 + mat.m20) / s;
+                y = (mat.m12 + mat.m21) / s;
+                z = 0.25f * s;
+            }
+            return new Quaternion(x, y, z, w);
+        }
+    }
+}

--- a/Assets/MatrixHelper/Runtime/Quartenion/QuaternionUtils.cs.meta
+++ b/Assets/MatrixHelper/Runtime/Quartenion/QuaternionUtils.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f807439168f84180aa280e9f6ab1b055

--- a/Assets/MatrixHelper/Tests/QuaternionUtilsTest.cs
+++ b/Assets/MatrixHelper/Tests/QuaternionUtilsTest.cs
@@ -1,0 +1,114 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace nitou.Tests {
+
+    public class QuaternionUtilsTest {
+        private const float Threshold = 1e-3f;
+
+        // 回転行列の回転成分(3x3)が一致することを検証する
+        private static void AssertRotationEqual(Matrix4x4 a, Matrix4x4 b, string label) {
+            for (int r = 0; r < 3; r++) {
+                for (int c = 0; c < 3; c++) {
+                    Assert.That(b[r, c], Is.EqualTo(a[r, c]).Within(Threshold), $"{label}: m{r}{c} 不一致");
+                }
+            }
+        }
+
+        // 検証用の代表的な回転（順序と角度）
+        private static Matrix4x4[] SampleMatrices() {
+            var orders = (EulerAngles.Type[])System.Enum.GetValues(typeof(EulerAngles.Type));
+            var angles = new[] {
+                new Vector3(0, 0, 0),    new Vector3(30, 40, 50),  new Vector3(-20, 80, 140),
+                new Vector3(90, 0, 0),   new Vector3(0, 90, 0),    new Vector3(0, 0, 90),
+                new Vector3(170, 10, -160), new Vector3(45, -45, 45),
+            };
+            var list = new System.Collections.Generic.List<Matrix4x4>();
+            foreach (var o in orders)
+                foreach (var a in angles)
+                    list.Add(new EulerAngles(o, a * Mathf.Deg2Rad).ToMatrix());
+            return list.ToArray();
+        }
+
+
+        #region 回転行列 ↔ クォータニオン
+
+        [Test]
+        public void 回転行列がクォータニオンを介して復元されること() {
+            foreach (var mat in SampleMatrices()) {
+                var q = QuaternionUtils.ToQuaternion(mat);
+                var restored = QuaternionUtils.FromQuaternion(q);
+                AssertRotationEqual(mat, restored, "mat→quat→mat");
+            }
+        }
+
+        [Test]
+        public void 単位クォータニオンが恒等行列を生成すること() {
+            var mat = QuaternionUtils.FromQuaternion(new Quaternion(0, 0, 0, 1));
+            AssertRotationEqual(Matrix4x4.identity, mat, "identity");
+        }
+
+        #endregion
+
+
+        #region オイラー角 ↔ クォータニオン
+
+        [Test]
+        public void オイラー角がクォータニオンを介して復元されること() {
+            foreach (EulerAngles.Type order in System.Enum.GetValues(typeof(EulerAngles.Type))) {
+                var input = new EulerAngles(order, new Vector3(25, 35, -40) * Mathf.Deg2Rad);
+                var q = input.ToQuaternion();
+                var output = EulerAngles.FromQuaternion(order, q);
+                AssertRotationEqual(input.ToMatrix(), output.ToMatrix(), $"euler→quat→euler {order}");
+            }
+        }
+
+        [Test]
+        public void 対称オイラー角がクォータニオンを介して復元されること() {
+            foreach (EulerAngles2.Type order in System.Enum.GetValues(typeof(EulerAngles2.Type))) {
+                var input = new EulerAngles2(order, 30 * Mathf.Deg2Rad, 60 * Mathf.Deg2Rad, -50 * Mathf.Deg2Rad);
+                var q = input.ToQuaternion();
+                var output = EulerAngles2.FromQuaternion(order, q);
+                AssertRotationEqual(input.ToMatrix(), output.ToMatrix(), $"euler2→quat→euler2 {order}");
+            }
+        }
+
+        #endregion
+
+
+        #region 軸‐角度 (AxisAngle)
+
+        [Test]
+        public void 軸角度が回転行列を介して復元されること() {
+            var axes = new[] { Vector3.right, Vector3.up, Vector3.forward, new Vector3(1, 2, 3), new Vector3(-2, 1, 0.5f) };
+            var angsDeg = new[] { 0f, 10f, 90f, 179f, -120f, 180f };
+            foreach (var axis in axes) {
+                foreach (var deg in angsDeg) {
+                    var input = new AxisAngle(axis, deg * Mathf.Deg2Rad);
+                    var restored = AxisAngle.FromMatrix(input.ToMatrix());
+                    AssertRotationEqual(input.ToMatrix(), restored.ToMatrix(), $"axisangle {axis} {deg}");
+                }
+            }
+        }
+
+        [Test]
+        public void 軸角度のToMatrixとToQuaternionが整合すること() {
+            var input = new AxisAngle(new Vector3(1, -2, 0.5f), 75 * Mathf.Deg2Rad);
+            var viaMatrix = input.ToMatrix();
+            var viaQuat = QuaternionUtils.FromQuaternion(input.ToQuaternion());
+            AssertRotationEqual(viaMatrix, viaQuat, "axisangle: ToMatrix vs ToQuaternion");
+        }
+
+        [Test]
+        public void オイラー角と軸角度が相互変換できること() {
+            foreach (EulerAngles.Type order in System.Enum.GetValues(typeof(EulerAngles.Type))) {
+                var input = new EulerAngles(order, new Vector3(15, -55, 70) * Mathf.Deg2Rad);
+                var aa = input.ToAxisAngle();
+                var output = EulerAngles.FromAxisAngle(order, aa);
+                AssertRotationEqual(input.ToMatrix(), output.ToMatrix(), $"euler→axisangle→euler {order}");
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Assets/MatrixHelper/Tests/QuaternionUtilsTest.cs.meta
+++ b/Assets/MatrixHelper/Tests/QuaternionUtilsTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 013e1a0a11c542e4ace545b06642a96c


### PR DESCRIPTION
## 概要
回転表現の相互変換を拡張し、**クォータニオン**と**軸‐角度（AxisAngle）**を追加します。規約は **右手系（ライブラリ準拠）** で統一しました。

> ⚠️ スタックPRです（base = `claude/inverse-all-orders` = #7）。マージ順は #3 → #4 → #7 → 本PR。

## 追加内容
**`QuaternionUtils`（新規）**
- `FromQuaternion(Quaternion) → Matrix4x4`
- `ToQuaternion(Matrix4x4) → Quaternion`（数値安定な Shepperd 法）

**`AxisAngle`（新規 struct）**
- `ToMatrix()`（ロドリゲスの公式）/ `ToQuaternion()`
- `FromMatrix()` / `FromQuaternion()` / `Identity`

**`EulerAngles` / `EulerAngles2`（partial 追加）**
- `ToQuaternion()` / `ToAxisAngle()`
- `FromQuaternion(order, q)` / `FromAxisAngle(order, aa)` … #7 の `ToEulerAngles` ディスパッチャを利用

## 規約について（重要）
本ライブラリの `Rx/Ry/Rz`・行列・オイラー角は**右手系**です。本PRのクォータニオンも右手系で統一し、`quat→行列` が既存 `Rx/Ry/Rz` と一致することを確認しています。

⚠️ `UnityEngine.Quaternion` は `(x,y,z,w)` のデータ容器として用いており、Unity の `Transform.rotation`（左手系）とは規約が異なります。**得られた `Quaternion` をそのまま `transform.rotation` に代入しないでください**（コード内コメントにも明記）。Unity と相互運用したい場合は、別途左右手系変換が必要です。

## 検証
- 全変換を同一の Rx/Ry/Rz 定義で Python に再現し、**回転行列の往復一致**で検証（`mat↔quat`・`axisangle↔mat`・特異点 θ=0/π を含め最大誤差 **~1e-15**）
- **C#に書いた式を逐語的にPythonへ転記**して再検証（ALL OK）
- C#側テスト追加: 行列↔クォータニオン、オイラー角↔クォータニオン（全12順序）、軸‐角度↔行列（θ=180°等の特異点含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dr6RhEUTL5GNFYk3aPywr3)_