### PR TITLE
docs: ライブラリ利用サンプル（RotationConversionSample）を追加

### DIFF
--- a/Assets/MatrixHelper/Samples.meta
+++ b/Assets/MatrixHelper/Samples.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0ad437d76f29473cbf9833f3bf13859b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MatrixHelper/Samples/MatrixHelper.Samples.asmdef
+++ b/Assets/MatrixHelper/Samples/MatrixHelper.Samples.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "MatrixHelper.Samples",
+    "rootNamespace": "nitou.Samples",
+    "references": [
+        "MatrixHelper"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/MatrixHelper/Samples/MatrixHelper.Samples.asmdef.meta
+++ b/Assets/MatrixHelper/Samples/MatrixHelper.Samples.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 27afc76056394c70845f7fe540f3f16b
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MatrixHelper/Samples/README.md
+++ b/Assets/MatrixHelper/Samples/README.md
@@ -1,0 +1,35 @@
+# MatrixHelper サンプル
+
+`MatrixHelper` の各回転表現の相互変換を体験するためのサンプルです。
+
+## 使い方
+
+1. シーン内の空の GameObject に `RotationConversionSample` をアタッチします。
+2. Inspector で **オイラー角の順序（`Order`）** と **角度（`Euler Degrees`, 度数法）** を設定します。
+3. Scene ビューに、回転後の座標軸が Gizmos で描画されます。
+   - 🔴 赤 … X 軸
+   - 🟢 緑 … Y 軸
+   - 🔵 青 … Z 軸
+   - 🟡 黄 … 軸‐角度（オイラーの回転定理）の回転軸
+4. コンポーネントの右クリックメニュー（ContextMenu）から、以下を実行できます。
+   - **Log All Representations** … オイラー角／回転行列／クォータニオン／軸‐角度を一覧表示
+   - **Verify Round Trip** … 各表現を経由して元の回転へ戻ることを確認（回転行列で誤差比較）
+   - **Log All Orders (same rotation)** … 同一の回転を 6 順序すべてで逆変換した結果を表示
+
+## 扱う API
+
+| 変換 | API |
+| --- | --- |
+| オイラー角 → 回転行列 | `EulerAngles.ToMatrix()` |
+| 回転行列 → オイラー角（順序指定） | `MatrixUtils.ToEulerAngles(mat, order)` |
+| オイラー角 → クォータニオン | `EulerAngles.ToQuaternion()` |
+| クォータニオン → オイラー角 | `EulerAngles.FromQuaternion(order, q)` |
+| オイラー角 → 軸‐角度 | `EulerAngles.ToAxisAngle()` |
+| 軸‐角度 → オイラー角 | `EulerAngles.FromAxisAngle(order, aa)` |
+
+## 注意（座標系）
+
+本ライブラリの回転は **右手系**（`MatrixUtils.Rx/Ry/Rz` と整合）で計算します。
+Unity の `Transform` / `Quaternion` は **左手系** のため規約が異なります。
+本サンプルの可視化は「回転行列が基底ベクトルをどう写すか」を右手系のまま描画しており、
+`transform.rotation` へ直接代入する用途には対応していません。

--- a/Assets/MatrixHelper/Samples/README.md.meta
+++ b/Assets/MatrixHelper/Samples/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 88a1457a2c2645678595f411c5124141
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MatrixHelper/Samples/RotationConversionSample.cs
+++ b/Assets/MatrixHelper/Samples/RotationConversionSample.cs
@@ -1,0 +1,147 @@
+using UnityEngine;
+
+namespace nitou.Samples {
+
+    /// <summary>
+    /// MatrixHelper の各回転表現（オイラー角・回転行列・クォータニオン・軸‐角度）の
+    /// 相互変換を体験するためのサンプル．
+    /// </summary>
+    /// <remarks>
+    /// シーン上のオブジェクトにアタッチすると、Inspector で指定したオイラー角に対応する
+    /// 回転後の座標軸（赤=X, 緑=Y, 青=Z）と、軸‐角度（黄）を Gizmos で描画する．
+    /// コンテキストメニューから各表現のログ出力・往復検証も実行できる．
+    ///
+    /// [NOTE] 本ライブラリは右手系（MatrixUtils.Rx/Ry/Rz と整合）で計算する．
+    ///  Unity の Transform/Quaternion（左手系）とは規約が異なるため、ここでの可視化は
+    ///  「回転行列が基底ベクトルをどう写すか」を右手系のまま描画している．
+    /// </remarks>
+    [ExecuteAlways]
+    public sealed class RotationConversionSample : MonoBehaviour {
+
+        [Header("入力（非対称オイラー角 i-j-k）")]
+        [SerializeField] private EulerAngles.Type _order = EulerAngles.Type.XYZ;
+
+        [Tooltip("各軸まわりの回転角 [degree]")]
+        [SerializeField] private Vector3 _eulerDegrees = new Vector3(30f, 45f, 60f);
+
+        [Header("Gizmo 設定")]
+        [SerializeField] private float _axisLength = 1.5f;
+        [SerializeField] private bool _drawAxisAngle = true;
+
+
+        /// <summary>現在の入力を表すオイラー角．</summary>
+        public EulerAngles Euler => new EulerAngles(_order, _eulerDegrees * Mathf.Deg2Rad);
+
+
+        /// ----------------------------------------------------------------------------
+        #region Gizmo
+
+        private void OnDrawGizmos() {
+            var euler = Euler;
+            Matrix4x4 m = euler.ToMatrix();
+            Vector3 origin = transform.position;
+
+            // 回転後の基底ベクトル（行列が e_x, e_y, e_z をどこへ写すか）
+            DrawAxis(origin, m.MultiplyVector(Vector3.right), Color.red);
+            DrawAxis(origin, m.MultiplyVector(Vector3.up), Color.green);
+            DrawAxis(origin, m.MultiplyVector(Vector3.forward), Color.blue);
+
+            // 軸‐角度（オイラーの回転定理）の回転軸
+            if (_drawAxisAngle) {
+                AxisAngle aa = euler.ToAxisAngle();
+                Gizmos.color = Color.yellow;
+                Gizmos.DrawLine(origin - aa.Axis * _axisLength, origin + aa.Axis * _axisLength);
+            }
+        }
+
+        private void DrawAxis(Vector3 origin, Vector3 dir, Color color) {
+            Gizmos.color = color;
+            Gizmos.DrawLine(origin, origin + dir.normalized * _axisLength);
+        }
+
+        #endregion
+
+
+        /// ----------------------------------------------------------------------------
+        #region コンテキストメニュー
+
+        /// <summary>
+        /// 入力オイラー角を、全表現へ変換してログ出力する．
+        /// </summary>
+        [ContextMenu("Log All Representations")]
+        public void LogAllRepresentations() {
+            var euler = Euler;
+            Matrix4x4 m = euler.ToMatrix();
+            Quaternion q = euler.ToQuaternion();
+            AxisAngle aa = euler.ToAxisAngle();
+
+            Debug.Log(
+                $"[RotationConversionSample]\n" +
+                $"  Euler({_order})   : {euler.ToStringDeg()}\n" +
+                $"  Quaternion       : ({q.x:F4}, {q.y:F4}, {q.z:F4}, {q.w:F4})\n" +
+                $"  AxisAngle        : {aa}\n" +
+                $"  Matrix(行ベクトル) : \n{FormatMatrix(m)}");
+        }
+
+        /// <summary>
+        /// 各表現を経由して元のオイラー角（が表す回転）に戻ることを確認する．
+        /// </summary>
+        [ContextMenu("Verify Round Trip")]
+        public void VerifyRoundTrip() {
+            var euler = Euler;
+            Matrix4x4 m = euler.ToMatrix();
+
+            // Euler → Matrix → Euler
+            var viaMatrix = MatrixUtils.ToEulerAngles(m, _order).ToMatrix();
+            // Euler → Quaternion → Euler
+            var viaQuat = EulerAngles.FromQuaternion(_order, euler.ToQuaternion()).ToMatrix();
+            // Euler → AxisAngle → Euler
+            var viaAxis = EulerAngles.FromAxisAngle(_order, euler.ToAxisAngle()).ToMatrix();
+
+            Debug.Log(
+                $"[RoundTrip] 最大誤差（回転行列比較）\n" +
+                $"  via Matrix     : {MaxDiff(m, viaMatrix):E2}\n" +
+                $"  via Quaternion : {MaxDiff(m, viaQuat):E2}\n" +
+                $"  via AxisAngle  : {MaxDiff(m, viaAxis):E2}");
+        }
+
+        /// <summary>
+        /// 同一の回転行列を、6種類すべての (i-j-k) 順序で逆変換した結果を出力する．
+        /// 順序ごとに角度表現が異なることを確認できる．
+        /// </summary>
+        [ContextMenu("Log All Orders (same rotation)")]
+        public void LogAllOrders() {
+            Matrix4x4 m = Euler.ToMatrix();
+
+            var sb = new System.Text.StringBuilder("[AllOrders] 同一回転を各順序で逆変換:\n");
+            foreach (EulerAngles.Type order in System.Enum.GetValues(typeof(EulerAngles.Type))) {
+                var e = MatrixUtils.ToEulerAngles(m, order);
+                sb.AppendLine($"  {order} : {e.AngleAtDegree()}");
+            }
+            Debug.Log(sb.ToString());
+        }
+
+        #endregion
+
+
+        /// ----------------------------------------------------------------------------
+        #region Helper
+
+        private static float MaxDiff(Matrix4x4 a, Matrix4x4 b) {
+            float max = 0f;
+            for (int r = 0; r < 3; r++)
+                for (int c = 0; c < 3; c++)
+                    max = Mathf.Max(max, Mathf.Abs(a[r, c] - b[r, c]));
+            return max;
+        }
+
+        private static string FormatMatrix(Matrix4x4 m) {
+            return
+                $"    | {m.m00,7:F3} {m.m01,7:F3} {m.m02,7:F3} |\n" +
+                $"    | {m.m10,7:F3} {m.m11,7:F3} {m.m12,7:F3} |\n" +
+                $"    | {m.m20,7:F3} {m.m21,7:F3} {m.m22,7:F3} |";
+        }
+
+        #endregion
+    }
+}

--- a/Assets/MatrixHelper/Samples/RotationConversionSample.cs.meta
+++ b/Assets/MatrixHelper/Samples/RotationConversionSample.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 72b860f589964e34926d7b878f8abaf6


### PR DESCRIPTION
## 概要
`MatrixHelper` の利用方法を体験できるサンプルを追加します。各回転表現（オイラー角・回転行列・クォータニオン・軸‐角度）の相互変換を、シーン上で可視化＋ログ確認できます。

> ⚠️ 本PRは全機能（#7 全順序逆変換 + #8 Quaternion/AxisAngle）が入った `claude/inverse-all-orders` をベースにしています。

## 追加内容
- `RotationConversionSample.cs` … `[ExecuteAlways]` な MonoBehaviour
  - Inspector で **順序** と **オイラー角[deg]** を指定
  - Gizmos で回転後の座標軸（🔴X / 🟢Y / 🔵Z）と軸‐角度の回転軸（🟡）を描画
  - ContextMenu:
    - **Log All Representations** … 4表現を一覧出力
    - **Verify Round Trip** … 各表現を経由した往復誤差を回転行列で比較
    - **Log All Orders** … 同一回転を6順序すべてで逆変換
- `MatrixHelper.Samples.asmdef`（`MatrixHelper` を参照）
- `README.md`（使い方・扱うAPI・座標系の注意）

## 扱う API
`EulerAngles.ToMatrix / ToQuaternion / ToAxisAngle`、`MatrixUtils.ToEulerAngles(mat, order)`、`EulerAngles.FromQuaternion / FromAxisAngle` など、本シリーズで追加した変換を一通り網羅しています。

## 注意
ライブラリは右手系のため、可視化は「回転行列が基底ベクトルを写す様子」を右手系のまま描画しています（`transform.rotation` への直接代入用途ではない旨を README/コメントに明記）。

なお Unity 実機での動作確認は未実施です（当環境では実行不可）。コンパイル対象 API の存在は確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dr6RhEUTL5GNFYk3aPywr3)_